### PR TITLE
optional rest.client.exec dependency for core 11.3

### DIFF
--- a/openai-assistant/META-INF/MANIFEST.MF
+++ b/openai-assistant/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  ch.ivyteam.ivy.webservice.execution;resolution:=optional,
  ch.ivyteam.lib.jackson,
  ch.ivyteam.ivy.jersey.client,
- javax.ws.rs
+ javax.ws.rs,
+ ch.ivyteam.ivy.rest.client.exec;resolution:=optional
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy

--- a/openai-assistant/pom.xml
+++ b/openai-assistant/pom.xml
@@ -16,7 +16,7 @@
     <repository>
       <id>ivy.nightly.release</id>
       <layout>p2</layout>
-      <url>https://p2.axonivy.com/p2/nightly-11.2/</url>
+      <url>https://p2.axonivy.com/p2/nightly/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
with this fix; you can maintain your change without starting to develop on multiple release trains.
